### PR TITLE
Associate traits with the current user in Segment

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -6,7 +6,7 @@ tunnel:
 scripts:
   - "/node_modules/jquery/dist/jquery.min.js"
   - "/node_modules/expect.js/expect.js"
-  - "/node_modules/sinon/pkg/sinon-1.15.4.js"
+  - "/node_modules/sinon/pkg/sinon-1.16.0.js"
   - "/build/auth0-metrics.js"
 browsers:
   - name: chrome

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -7,6 +7,7 @@ scripts:
   - "/node_modules/jquery/dist/jquery.min.js"
   - "/node_modules/expect.js/expect.js"
   - "/node_modules/sinon/pkg/sinon-1.16.0.js"
+  - "/node_modules/lodash/index.js"
   - "/build/auth0-metrics.js"
 browsers:
   - name: chrome

--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ Sends information of a custom event to track.
 
 ### .identify(id, traits, callback)
 Sends information of an identification (login/signup) to track.
-> NOTE: This method's arguments do not pair with the ones of `window.analytics` from Segment's [analytics.js](https://github.com/segmentio/analytics.js). In order to assign properties to an anonymous user you need to proxy directly to Segment by doing `metricsLib.segment().identify()` instead. Check Segment's (documentation)[https://segment.com/docs/libraries/analytics.js/#identify] for a detailed specification and use cases.
+> NOTE: This method's arguments do not pair with the ones of `window.analytics` from Segment's [analytics.js](https://github.com/segmentio/analytics.js). You can proxy directly to Segment by doing `metricsLib.segment().identify()` instead. Check Segment's (documentation)[https://segment.com/docs/libraries/analytics.js/#identify] for a detailed specification and use cases.
 
 #### Parameters
 * `id` user id to identify the current user to
 * `traits` additional properties to set to the user
 * `callback` a function to call after sending this event
+
+You can omit the user `id` if you want to associate `traits` with the currently identified user, anonymous or not. You can also omit `traits` if all you want to do is associate an `id`. Finally, `callback` is optional and can always be omitted.
 
 ### .alias(id, callback)
 Sends an alias (renaming a previous id to a new one).
@@ -74,6 +76,3 @@ Traits (additional properties) of the current user
 Executes a callback when segment finishes loading.
 #### Parameters
 * `cb` function to run when segment finishes loading.
-
-## Known issues
-If you need to add traits to the current user without identifying the user id, you need to run segment's native identify, using metrics.segment().identify()

--- a/index.js
+++ b/index.js
@@ -109,23 +109,24 @@ Auth0Metrics.prototype.setUserId = function(uid) {
 
 
 Auth0Metrics.prototype.identify = function (id, traits, callback) {
+  var args = [].slice.call(arguments);
+
+  // Argument reshuffling.
+  if (_.isFunction(traits)) callback = traits, traits = null;
+  if (_.isObject(id)) traits = id, id = null;
+
   var segment = this.segment();
 
-  if(typeof id !== 'string'){
-    traits = id;
-    id = null;
-  }
-
   if (segment.loaded) {
-    if(null != id){
-      this.setUserId(id);
+    if (null != id) this.setUserId(id);
 
-      try {
-        segment.identify(id, traits);
-      } catch (error) {
-        debug('segment analytics error: %o', error);
-      }
+    try {
+      if (_.isFunction(args[args.length - 1])) args.pop();
+      segment.identify.apply(segment, args);
+    } catch (error) {
+      debug('segment analytics error: %o', error);
     }
+
   }else{
     debug('identify call without segment');
   }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "packageify": "^0.2.0",
     "phantomjs": "^1.9.7-15",
     "rimraf": "~2.2.2",
-    "sinon": "^1.15.4",
+    "sinon": "1.16.0",
     "through": "^2.3.4",
     "uglify-js": "~2.4.15",
     "unreleased": "^0.0.5",

--- a/test_harness.html
+++ b/test_harness.html
@@ -11,7 +11,7 @@
   <!-- support -->
   <script src="/node_modules/mocha/mocha.js"></script>
   <script src="/node_modules/expect.js/expect.js"></script>
-  <script src="/node_modules/sinon/pkg/sinon-1.15.4.js"></script>
+  <script src="/node_modules/sinon/pkg/sinon-1.16.0.js"></script>
   <script src="/node_modules/jquery/dist/jquery.js"></script>
 
   <!-- libs -->


### PR DESCRIPTION
Calls to `metrics.identify` weren't delegated to Segment's `analytics.identify` when they didn't provide an user id. This prevented associating traits with the current user (anonymous or not). See auth0/auth0-metrics/issues/2 for the motivation for the change.

**A/B test demo request to DWH**
<img width="1329" alt="dwh" src="https://cloud.githubusercontent.com/assets/120195/9496566/5082e9a6-4be7-11e5-8ad2-453752dfce93.png">

**A/B test demo request to segment**
<img width="1329" alt="segment" src="https://cloud.githubusercontent.com/assets/120195/9496576/59c09c66-4be7-11e5-8caf-aaf8de815406.png">

**Direct call to segment before changes**

``` js
metrics.segment().identify({'ab:website-pricing-packages': "original"})
```

<img width="1329" alt="direct-call-to-segment" src="https://cloud.githubusercontent.com/assets/120195/9496601/7e9a4726-4be7-11e5-8bbe-80f0c47d7145.png">
