### PR TITLE
Add metrics.page uuid property sent on each call

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ Auth0Metrics.prototype.identify = function (id, traits, callback) {
 
   // Argument reshuffling.
   if (_.isFunction(traits)) callback = traits, traits = null;
-  if (_.isObject(id)) traits = id, id = null;
+  if (_.isPlainObject(id)) traits = id, id = null;
 
   var segment = this.segment();
 
@@ -246,7 +246,7 @@ Auth0Metrics.prototype.extendPageArguments = function(args) {
   }
 
   for (var i = 0; i < args.length; i++) {
-    if (_.isObject(args[i])) {
+    if (_.isPlainObject(args[i])) {
       return _.assign(args[i], base), args;
     }
   }

--- a/lib/dwh/index.js
+++ b/lib/dwh/index.js
@@ -148,7 +148,7 @@ dwh.prototype.annexData = function(data){
       data = null;
     }
 
-    if (_.isObject(event)) {
+    if (_.isPlainObject(event)) {
       data = event;
       event = null;
     }

--- a/lib/dwh/index.js
+++ b/lib/dwh/index.js
@@ -118,7 +118,7 @@ dwh.prototype.annexData = function(data){
   return data;
 }
 
-  dwh.prototype.genericRequest = function(url, type, data, callback){
+  dwh.prototype.genericRequest = function(url, type, data, callback) {
 
     var data = this.annexData(data);
 
@@ -133,15 +133,30 @@ dwh.prototype.annexData = function(data){
   }
 
 
-  dwh.prototype.track = function(event, data, callback){
+  dwh.prototype.track = function(event, data, callback) {
     this.genericRequest(this.url, "track", { userId: this.userid(), event: event, properties: data }, callback);
   }
 
-  dwh.prototype.page = function(callback){
-    this.genericRequest(this.url, "page", {userId: this.userid()}, callback);
+  dwh.prototype.page = function(event, data, callback) {
+    if ('function' === typeof event) {
+      callback = event;
+      data = null;
+    }
+
+    if ('function' === typeof data) {
+      callback = data;
+      data = null;
+    }
+
+    if (_.isObject(event)) {
+      data = event;
+      event = null;
+    }
+
+    this.genericRequest(this.url, "page", { userId: this.userid(), properties: data }, callback);
   }
 
-  dwh.prototype.identify = function(id, traits, callback){
+  dwh.prototype.identify = function(id, traits, callback) {
     var newId = id;
     if(newId == null){
       newId = this.userid();
@@ -155,7 +170,7 @@ dwh.prototype.annexData = function(data){
     this.genericRequest(this.url, "identify", {userId: newId, traits: newTraits}, callback);
   }
 
-  dwh.prototype.alias = function(id, callback){
+  dwh.prototype.alias = function(id, callback) {
     var newId = id;
     if(newId == null){
       return;

--- a/support/development-demo/index.html
+++ b/support/development-demo/index.html
@@ -136,6 +136,14 @@
 
           $('#pageview-button').on('click', function() {
             metrics.page();
+            metrics.page('PI');
+            metrics.page('Pricing', {something: 'here'});
+            metrics.page({url: 'https://asdasd.com', something: 'else'});
+            function here () {console.log('here')};
+            metrics.page(here);
+            metrics.page('PI', here);
+            metrics.page('Pricing', {something: 'here'}, here);
+            metrics.page({url: 'https://asdasd.com', something: 'else'}, here);
           });
 
           $('#track-button').on('click', function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -395,13 +395,10 @@ describe('Auth0 - Metrics', function () {
       this.anon_id = readCookie('ajs_anonymous_id');
       var fServer = this.server = sinon.fakeServer.create();
       this.server.respondImmediately = true;
-      this.server.respondWith("POST", DWH_URL,
-            [200, { "Content-Type": "application/json" },
-             '{}'])
+      this.server.respondWith("POST", DWH_URL, responses.successJSON);
       this.lastReq = function(){
         return fServer.requests[fServer.requests.length-1];
       }
-
     });
 
     after(function () {
@@ -409,8 +406,6 @@ describe('Auth0 - Metrics', function () {
       this.metrics._segment = segmentSave;
       this.anon_id = null;
     });
-
-
 
     it('should track the current page', function (done) {
       var ctx = this;


### PR DESCRIPTION
This PR covers the following use cases

``` javascript
metrics.page()
metrics.page('title')
metrics.page('title', {some: 'extra-props'})
metrics.page({just: 'some-extra-props'})
```

I wouldn't mind if @pseibelt and @cabralmartin take a look at this.

BTW, should also accept the old callback property at the end of each.
