### PR TITLE
No longer load all social tags by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ build/auth0-lock-*.js.map
 build
 
 .idea
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [2.0.0] - 2019-02-28
+
+### Fixed
+
+- [] Rollback change in version to use script (`Hernan Zalazar`)
+  https://github.com/auth0/metrics/commit/a070127ac8f39c8baaefe439e82a09f9dee5ea10
+- [] Bump version of library (`Hernan Zalazar`)
+  https://github.com/auth0/metrics/commit/9a76ce4e02f10c189822bb8f6af019531d50a4d4
+- [] Add `tags` option to send config for tags (`Hernan Zalazar`)
+  https://github.com/auth0/metrics/commit/4648473050a5c65a40f1403ac89599963d427925
+- [] Use latest auth0-tag-manager version from NPM (`Hernan Zalazar`)
+  https://github.com/auth0/metrics/commit/19c691dfc6917ec4462f13d5a5af0027568c9d30
+- [] Load jquery from CDN for tests (`Hernan Zalazar`)
+  https://github.com/auth0/metrics/commit/8bd72338cdb833119a20842c66ee67ef46132ca8
+- [] Ignore DS_Store files (`Hernan Zalazar`)
+  https://github.com/auth0/metrics/commit/895c0238fe0375d8e997f67b177599174dc16135
+
 ## [1.5.0] - 2017-05-16
 
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function Auth0Metrics (segmentKey, dwhEndpoint, label, options) {
   // Save additional instance configuration in $options
   if (options) {
     for (var key in options) {
-      if (options.hasOwnProperty(key)) {
+      if (options.hasOwnProperty(key) && key !== 'tags') {
           this.$options[key] = options[key];
       }
     }
@@ -52,7 +52,7 @@ function Auth0Metrics (segmentKey, dwhEndpoint, label, options) {
 
   debug("Loading DWH endpoint library...")
 
-  this.dwh = require('./lib/dwh')(dwhEndpoint, label);
+  this.dwh = require('./lib/dwh')(dwhEndpoint, _.defaults({ label: label }, (options || {}).tags));
 
   debug("Loading segment...");
 
@@ -238,12 +238,12 @@ Auth0Metrics.prototype.getData = function() {
 
 /**
  * Strip out selected query paramters from the url
- * 
- * @param {String} url 
+ *
+ * @param {String} url
  * @return {String}
  */
 Auth0Metrics.prototype.removeQueryParams = function(url) {
-  
+
   if (url && this.$options.removeQueryParam && this.$options.removeQueryParam.length > 0) {
     for (var i = 0; i < this.$options.removeQueryParam.length; i++){
       var regExp = new RegExp('&*' + this.$options.removeQueryParam[i].key + '=' + this.$options.removeQueryParam[i].value, 'gmi');

--- a/lib/tag-manager/index.js
+++ b/lib/tag-manager/index.js
@@ -1,7 +1,7 @@
 var debug = require('debug')('auth0-metrics');
 var initialize = require('auth0-tag-manager').initialize;
 
-module.exports = function bootTagManager(label) {
+module.exports = function bootTagManager(config) {
   var analytics = {};
   var readyCallbacks = [];
 
@@ -17,7 +17,7 @@ module.exports = function bootTagManager(label) {
     });
   }
 
-  var tagManager = initialize({ label: label }, tagManagerReady);
+  var tagManager = initialize(config, tagManagerReady);
 
   var methods = [
     'trackSubmit',

--- a/lib/tag-manager/index.js
+++ b/lib/tag-manager/index.js
@@ -1,11 +1,24 @@
 var debug = require('debug')('auth0-metrics');
-var initialize = require('auth0-metrics-tag-manager').initialize;
+var initialize = require('auth0-tag-manager').initialize;
 
 module.exports = function bootTagManager(label) {
-  var tagManager = initialize(label, tagManagerReady);
-
   var analytics = {};
   var readyCallbacks = [];
+
+  function tagManagerReady() {
+    analytics.loaded = true;
+    readyCallbacks.forEach(function (callback) {
+      try {
+        callback();
+      } catch (e) {
+        debug('Error while calling ready callback');
+        debug(e);
+      }
+    });
+  }
+
+  var tagManager = initialize({ label: label }, tagManagerReady);
+
   var methods = [
     'trackSubmit',
     'trackClick',
@@ -39,25 +52,15 @@ module.exports = function bootTagManager(label) {
     }
   }
 
-  analytics.track = tagManager.track;
-  analytics.page = tagManager.page;
-  analytics.invoked = true;
-  analytics.loaded = false;
-  analytics.SNIPPET_VERSION = '3.0.1';
+  if (tagManager) {
+    analytics.track = tagManager.track;
+    analytics.page = tagManager.page;
+    analytics.invoked = true;
+    analytics.loaded = false;
+    analytics.SNIPPET_VERSION = '3.0.1';
+  }
 
   window.analytics = analytics;
 
   return analytics;
-
-  function tagManagerReady() {
-    analytics.loaded = true;
-    readyCallbacks.forEach(function (callback) {
-      try {
-        callback();
-      } catch (e) {
-        debug('Error while calling ready callback');
-        debug(e);
-      }
-    });
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-metrics",
-  "version": "2.0.0",
+  "version": "1.6.2",
   "description": "Auth0 Metrics",
   "main": "./index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-metrics",
-  "version": "1.6.2",
+  "version": "2.0.0",
   "description": "Auth0 Metrics",
   "main": "./index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",
   "dependencies": {
-    "auth0-tag-manager": "auth0/auth0-tag-manager#1.0.4",
+    "auth0-tag-manager": "^2.0.7",
     "component-cookie": "^1.1.2",
     "component-url": "^0.2.1",
     "debug": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exec": "~0.4.2",
     "grunt-jsdoc": "^0.6.8",
-    "jquery": "^2.1.3",
     "mocha": "1.20.1",
     "mold-source-map": "^0.3.0",
     "packageify": "^0.2.0",

--- a/support/development-demo/index.html
+++ b/support/development-demo/index.html
@@ -73,7 +73,9 @@
       </div>
     </div>
 
-    <script src="/node_modules/jquery/dist/jquery.js"></script>
+    <script
+			  src="https://code.jquery.com/jquery-2.2.4.min.js"
+			  crossorigin="anonymous"></script>
     <script src="/auth0-metrics.js"></script>
     <script>
 

--- a/test_harness.html
+++ b/test_harness.html
@@ -12,7 +12,10 @@
   <script src="/node_modules/mocha/mocha.js"></script>
   <script src="/node_modules/expect.js/expect.js"></script>
   <script src="/node_modules/sinon/pkg/sinon-1.16.0.js"></script>
-  <script src="/node_modules/jquery/dist/jquery.js"></script>
+  <script
+  src="https://code.jquery.com/jquery-2.2.4.min.js"
+  crossorigin="anonymous"></script>
+
   <script src="/node_modules/lodash/index.js"></script>
 
   <!-- libs -->


### PR DESCRIPTION
No longer load all social tags by default, useful for Auth0 Dashboard were we dont need them. This bumps the lib to a new major (v2.0.0)