### PR TITLE
updating readme CDN links for 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To build and run the library locally, you can run
 Using our CDN is the preferred solution. Just add the following line in your project's HTML head and you are done.
 
 ```html
-<script src="https://cdn.auth0.com/website/js/1.6.0/auth0-metrics-min.js"></script>
+<script src="https://cdn.auth0.com/js/m/2.0/auth0-metrics.min.js"></script>
 ```
 
 Then you have to call the constructor with the correct dev/prod variables
@@ -61,10 +61,10 @@ will be transformed to
 
 ### Loader
 
-A script that will asynchronously load `auth0-metrics.js` is also provided.
+A script that will asynchronously load `auth0-metrics.js` is also provided and can be loaded via CDN.
 
 ```html
-<script src="auth0-metrics-loader.js"></script>
+<script src="https://cdn.auth0.com/js/m/2.0/auth0-metrics-loader.min.js"></script>
 <script>
   metricsLib.load({
     segmentKey: 'segmentKey',


### PR DESCRIPTION
### Description

This PR updates the links to the 2.0.0 version of metrics on the CDN.  It also specifically calls out the CDN link for the loader (also for version 2.0.0).

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
